### PR TITLE
REST API

### DIFF
--- a/controllers/apiv1/announcements.go
+++ b/controllers/apiv1/announcements.go
@@ -103,6 +103,38 @@ func GetAnnouncements(ctx *macaron.Context) {
     ctx.JSON(http.StatusOK, announcements)
 }
 
+func GetAnnouncement(ctx *macaron.Context) {
+    var res Category
+
+    r, err := http.Get("https://forums.spongepowered.org/c/announcements.json?order=created")
+    if err != nil {
+        ctx.Error(http.StatusInternalServerError, "Can't access announcements!")
+        return
+    }
+
+    err = json.NewDecoder(r.Body).Decode(&res)
+    if err != nil {
+        ctx.Error(http.StatusInternalServerError, "Can't access announcements!")
+        return
+    }
+
+    var topics []Topic = res.TopicList.GetRegularTopics()
+
+    topicId, err := strconv.ParseInt(ctx.Params(":topic"), 2, 64)
+    if err != nil {
+        ctx.Error(http.StatusInternalServerError, "Failed to get announcement id!")
+        return
+    }
+
+    announcement, err := getAnnouncement(topics[topicId])
+    if err != nil {
+        ctx.Error(http.StatusInternalServerError, "Failed to get announcement!")
+        return
+    }
+
+    ctx.JSON(http.StatusOK, announcement)
+}
+
 func getAnnouncements(topics []Topic) ([]Announcement, error) {
     var announcements []Announcement = []Announcement{}
 

--- a/controllers/apiv1/announcements.go
+++ b/controllers/apiv1/announcements.go
@@ -23,7 +23,7 @@
  * THE SOFTWARE.
  */
 
-package controllers
+package apiv1
 
 import (
     "strconv"
@@ -71,11 +71,6 @@ type TopicResponse struct {
     PostStream PostStream `json:"post_stream"`
 }
 
-type AnnouncementView struct {
-    First Announcement `json:"first"`
-    Second Announcement `json:"second"`
-}
-
 type Announcement struct {
     Title string `json:"title"`
     Content string `json:"content"`
@@ -99,22 +94,28 @@ func GetAnnouncements(ctx *macaron.Context) {
 
     var topics []Topic = res.TopicList.GetRegularTopics()
 
-    first, err := getAnnouncement(topics[0])
+    announcements, err := getAnnouncements(topics)
     if err != nil {
-        ctx.Error(http.StatusInternalServerError, "Can't access the first topic!")
+        ctx.Error(http.StatusInternalServerError, "Failed to get announcements!")
         return
     }
 
-    second, err := getAnnouncement(topics[1])
-    if err != nil {
-        ctx.Error(http.StatusInternalServerError, "Can't access the second topic!")
-        return
+    ctx.JSON(http.StatusOK, announcements)
+}
+
+func getAnnouncements(topics []Topic) ([]Announcement, error) {
+    var announcements []Announcement = []Announcement{}
+
+    for _, topic := range topics {
+        announcement, err := getAnnouncement(topic)
+        if err != nil {
+            return nil, err
+        } else {
+            announcements = append(announcements, announcement)
+        }
     }
 
-    ctx.JSON(http.StatusOK, &AnnouncementView{
-        First: first,
-        Second: second,
-    })
+    return announcements, nil
 }
 
 func getAnnouncement(topic Topic) (Announcement, error) {

--- a/spongehome.go
+++ b/spongehome.go
@@ -28,6 +28,7 @@ package main
 import (
 	"fmt"
 	"github.com/SpongePowered/SpongeHome/controllers"
+	"github.com/SpongePowered/SpongeHome/controllers/apiv1"
 	"github.com/go-macaron/pongo2"
 	"github.com/sethvargo/go-fastly"
 	"gopkg.in/macaron.v1"
@@ -84,7 +85,14 @@ func main() {
 	m.Get("/sponsors", controllers.GetSponsors)
 	m.Get("/chat", controllers.GetChat)
 	m.Get("/statusz", controllers.GetStatusz)
-	m.Get("/announcements.json", controllers.GetAnnouncements)
+
+	// API
+	m.Group("/api", func() {
+		// V1
+		m.Group("/v1", func() {
+			m.Get("/announcements", apiv1.GetAnnouncements)
+		})
+	})
 
 	go clearFastly()
 

--- a/spongehome.go
+++ b/spongehome.go
@@ -91,6 +91,7 @@ func main() {
 		// V1
 		m.Group("/v1", func() {
 			m.Get("/announcements", apiv1.GetAnnouncements)
+			m.Get("/announcement/:topic", apiv1.GetAnnouncement)
 		})
 	})
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -263,16 +263,18 @@ THE SOFTWARE.
         methods: {
             fetchData: function () {
                 var self = this;
-                $.get('/api/v1/announcements', function (data) {
+                $.get('/api/v1/announcement/0', function (data) {
                     self.first = {
-                        title: data[0].title,
-                        content: jQuery.truncate(data[0].content, 450),
-                        url: data[0].link
+                        title: data.title,
+                        content: jQuery.truncate(data.content, 450),
+                        url: data.link
                     };
+                });
+                $.get('/api/v1/announcement/1', function (data) {
                     self.second = {
-                        title: data[1].title,
-                        content: jQuery.truncate(data[1].content, 450),
-                        url: data[1].link
+                        title: data.title,
+                        content: jQuery.truncate(data.content, 450),
+                        url: data.link
                     };
                 });
             }

--- a/templates/index.html
+++ b/templates/index.html
@@ -263,16 +263,16 @@ THE SOFTWARE.
         methods: {
             fetchData: function () {
                 var self = this;
-                $.get('/announcements.json', function (data) {
+                $.get('/api/v1/announcements', function (data) {
                     self.first = {
-                        title: data.first.title,
-                        content: jQuery.truncate(data.first.content, 450),
-                        url: data.first.link
+                        title: data[0].title,
+                        content: jQuery.truncate(data[0].content, 450),
+                        url: data[0].link
                     };
                     self.second = {
-                        title: data.second.title,
-                        content: jQuery.truncate(data.second.content, 450),
-                        url: data.second.link
+                        title: data[1].title,
+                        content: jQuery.truncate(data[1].content, 450),
+                        url: data[1].link
                     };
                 });
             }


### PR DESCRIPTION
## Routes
- /api/v1/announcements
- /api/v1/announcement/:id
## Usecase
- Homepage (replaces horrid current solution)
- Future PR(s) (top secret :p)
## Running Instance

This PR is currently running on my staging instance of SpongeHome over at https://www-sponge-staging.jamierocks.uk/
## Notes

There is definitely more routes that the API can have, however I am of the opinion that at the current time this PR should not facilitate such routes.
