### PR TITLE
Added space between "on" & "GitHub"

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -97,7 +97,7 @@ THE SOFTWARE.
                 <div class="footer-col col-md-4">
                     <h3>Open Source</h3>
                     <p>
-                        Sponge is an Open Source project, our source code is freely available on<a href="https://github.com/SpongePowered">GitHub</a>.
+                        Sponge is an Open Source project, our source code is freely available on <a href="https://github.com/SpongePowered">GitHub</a>.
                     </p>
                 </div>
                 <div class="footer-col col-md-4">


### PR DESCRIPTION
Just a typo. Found in the footer section of the site.
