### PR TITLE
Register /statusz only when environment variable is set

### DIFF
--- a/controllers/statusz.go
+++ b/controllers/statusz.go
@@ -32,22 +32,38 @@ import (
 	"regexp"
 )
 
-var (
-	buildNameRe = regexp.MustCompile(`^(.+)-([0-9]+)$`)
-)
+const service = "SpongeHome"
 
-func GetStatusz(ctx *macaron.Context) {
-	buildNamePieces := buildNameRe.FindStringSubmatch(os.Getenv("OPENSHIFT_BUILD_NAME"))
+func readStatus() interface{} {
+	buildName := os.Getenv("OPENSHIFT_BUILD_NAME")
+	if buildName == "" {
+		return nil
+	}
+
+	buildNameRe := regexp.MustCompile(`^(.+)-([0-9]+)$`)
+	buildNamePieces := buildNameRe.FindStringSubmatch(buildName)
 	jobName := buildNamePieces[1]
 	buildNum := buildNamePieces[2]
 	buildTag := os.Getenv("OPENSHIFT_BUILD_NAMESPACE") + "/" + os.Getenv("OPENSHIFT_BUILD_NAME")
-	ctx.JSON(http.StatusOK, map[string]string{
+
+	return map[string]string{
 		"BUILD_NUMBER": buildNum,
 		"GIT_BRANCH":   os.Getenv("OPENSHIFT_BUILD_REFERENCE"),
 		"GIT_COMMIT":   os.Getenv("OPENSHIFT_BUILD_COMMIT"),
 		"JOB_NAME":     jobName,
 		"BUILD_TAG":    buildTag,
 		"SPONGE_ENV":   os.Getenv("SPONGE_ENV"),
-		"SERVICE":      "SpongeHome",
-	})
+		"SERVICE":      service,
+	}
+}
+
+func StatuszHandler() macaron.Handler {
+	status := readStatus()
+	if status == nil {
+		return nil
+	}
+
+	return func(ctx macaron.Render) {
+		ctx.JSON(http.StatusOK, status)
+	}
 }

--- a/spongehome.go
+++ b/spongehome.go
@@ -88,8 +88,11 @@ func main() {
 	m.Get("/", controllers.GetHomepage)
 	m.Get("/sponsors", controllers.GetSponsors)
 	m.Get("/chat", controllers.GetChat)
-	m.Get("/statusz", controllers.GetStatusz)
 	m.Get("/announcements.json", controllers.GetAnnouncements)
+
+	if statuszHandler := controllers.StatuszHandler(); statuszHandler != nil {
+		m.Get("/statusz", statuszHandler)
+	}
 
 	go clearFastly()
 


### PR DESCRIPTION
Prevents errors when going to `/statusz` with the environment variable not set. Additionally it will only read the environment variables once and cache the resulting map.