### PR TITLE
Improve gulp watch performance and a few other minor fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: 'node'
+node_js: 6
 
 env:
   global:

--- a/controllers/html.go
+++ b/controllers/html.go
@@ -31,9 +31,10 @@ import (
 )
 
 func html(ctx *macaron.Context, file string, page string, title string) {
-	ctx.Data["min"] = ""
 	if macaron.Env == macaron.PROD {
 		ctx.Data["min"] = ".min"
+	} else {
+		ctx.Data["min"] = ""
 	}
 
 	ctx.Data["title"] = title

--- a/controllers/index.go
+++ b/controllers/index.go
@@ -44,7 +44,7 @@ var (
 			Image: "/assets/img/sponsors/enjin.png",
 			Link:  "https://www.enjin.com/",
 		},
-        {
+		{
 			Name:  "Apex Hosting",
 			Image: "/assets/img/sponsors/apexhosting.png",
 			Link:  "https://apexminecrafthosting.com/",

--- a/package.json
+++ b/package.json
@@ -24,10 +24,8 @@
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.3.2",
     "gulp-uglify": "^2.0.0",
-    "vinyl-named": "^1.1.0",
     "vue-loader": "^9.7.0",
-    "webpack": "^2.1.0-beta.25",
-    "webpack-stream": "^3.2.0"
+    "webpack": "^2.1.0-beta.25"
   },
   "scripts": {
     "gulp": "gulp"

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -30,7 +30,7 @@ import {Platforms as PlatformData} from 'downloads/platforms'
 // Dummy router-link for index page, uses vue-router on downloads page
 Vue.component('router-link', {
     props: {
-        to: [String, Object],
+        to: Object,
         tag: {
             type: String,
             default: 'a'

--- a/templates/base.html
+++ b/templates/base.html
@@ -42,7 +42,7 @@ THE SOFTWARE.
     <link href="/assets/css/spongehome{{ min }}.css" rel="stylesheet">
 
     <!-- Custom Fonts -->
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome{{ min }}.css" rel="stylesheet" />
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome{{ min }}.css" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet">
 </head>
 <body id="{{ page }}-page">

--- a/templates/vue.html
+++ b/templates/vue.html
@@ -26,7 +26,7 @@ THE SOFTWARE.
 {% extends "base.html" %}
 
 {% block javascript %}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.0.3/vue{{ min }}.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.0.5/vue{{ min }}.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/vue-resource/1.0.3/vue-resource{{ min }}.js"></script>
 {% block vue_javascript %}{% endblock %}
 <script src="/assets/js/{{ page }}{{ min }}.js"></script>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,15 @@
-var webpack = require('webpack'),
-    path = require('path');
+const webpack = require('webpack');
 
-module.exports = function (env) {
+function createConfig(env) {
     var config = {
         devtool: 'eval',
 
+        entry: {
+            index: 'index'
+        },
+
         output: {
+            path: __dirname + '/public/assets/js',
             filename: '[name].js'
         },
 
@@ -19,21 +23,22 @@ module.exports = function (env) {
                 {
                     test: /\.vue$/,
                     loader: 'vue',
+                    exclude: /node_modules/
                 }
             ],
         },
 
         resolve: {
             modules: [
-                path.resolve(__dirname, 'src/js'),
-                path.resolve(__dirname, 'src/vue'),
+                'src/js',
+                'src/vue'
             ]
         },
 
         plugins: [
             new webpack.DefinePlugin({
                 'process.env': {
-                    NODE_ENV: '"' + env + '"'
+                    NODE_ENV: JSON.stringify(env),
                 }
             })
         ]
@@ -52,4 +57,7 @@ module.exports = function (env) {
     }
 
     return config
-};
+}
+
+exports.development = createConfig('development');
+exports.production = createConfig('production');


### PR DESCRIPTION
- Run webpack directly from gulp instead of through webpack-stream. That allows webpack to cache metadata so subsequent rebuilds are much faster.
- Update Vue and Font Awesome for some bug fixes.
- Use Node JS 6 on Travis so it uses the same version as the Dockerfile.
- Small bug fix for `index.js`