### PR TITLE
Remove fixed max width of homepage

### DIFF
--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -38,7 +38,6 @@ body {
 
   position: relative;
   overflow-x: hidden;
-  max-width: 1920px;
   margin: 0 auto;
 }
 

--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -24,10 +24,9 @@
  */
 
 header {
-  background-attachment: fixed;
   background-image: url(../img/backgrounds/sponsors-content.jpg);
   background-repeat: no-repeat;
-  background-size: 1920px 100%;
+  background-size: cover;
   background-position: center;
   color: $sponge_dark_grey;
   padding: 50px 0;

--- a/src/scss/_topbar.scss
+++ b/src/scss/_topbar.scss
@@ -43,7 +43,6 @@ $sp_logo_width: 200px;
   z-index: 9999;
 
   width: 100%;
-  max-width: 1920px;
   height: $sp_topbar_height;
 
   background-color: $sponge_grey;


### PR DESCRIPTION
Currently, the website has a explicit max width of 1920px which makes it look weird on monitors which have more than 1920px horizontally:

![screen shot 2016-11-14 at 14 34 58](https://cloud.githubusercontent.com/assets/3035868/20266845/40af9ea2-aa78-11e6-8b67-acecc956b757.png)

Of course, our header is only 1920px wide, but in my opinion it's a better idea to scale the header (with some reduced quality) than to just fix the horizontal size to 1920px:

![screen shot 2016-11-14 at 14 34 46](https://cloud.githubusercontent.com/assets/3035868/20266843/3abf393a-aa78-11e6-9583-e15307a337fe.png)

With these changes the header will always adapt to the correct size.