### PR TITLE
Cache improvements and other minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,9 @@ command line. SpongeHome will now be running locally on port 4000.
 
 **NOTE:** You will need to rerun this when you make a change to the Golang
 source.
+
+## Environment variables
+**Optional**:
+- `MACARON_ENV=production`: Set the application in production mode
+- `PORT`: Modify the port of the HTTP server
+- `FASTLY_CACHE=API_KEY/SERVICE_ID[;healthcheck]`: Purge Fastly cache after start and hide health checks from the log

--- a/controllers/announcements.go
+++ b/controllers/announcements.go
@@ -27,6 +27,8 @@ package controllers
 
 import (
 	"encoding/json"
+	"github.com/SpongePowered/SpongeWebGo/cache"
+	"github.com/SpongePowered/SpongeWebGo/fastly"
 	"gopkg.in/macaron.v1"
 	"log"
 	"net/http"
@@ -84,6 +86,12 @@ type Announcement struct {
 }
 
 func GetAnnouncements(ctx *macaron.Context, logger *log.Logger) {
+	header := ctx.Header()
+
+	// Override cache headers
+	header.Add(cache.CacheControlHeader, cache.DynamicContentOptions)
+	header.Add(fastly.SurrogateControlHeader, cache.SurrogateDynamicContentOptions)
+
 	var res Category
 
 	r, err := http.Get("https://forums.spongepowered.org/c/announcements.json?order=created")

--- a/controllers/header.go
+++ b/controllers/header.go
@@ -1,0 +1,22 @@
+package controllers
+
+import (
+	"github.com/SpongePowered/SpongeWebGo/cache"
+	"github.com/SpongePowered/SpongeWebGo/fastly"
+	"net/http"
+)
+
+func AddHeaders(resp http.ResponseWriter) {
+	header := resp.Header()
+
+	// TODO: Needs more testing and a few changes to make it more restrictive
+	/*header.Add("Content-Security-Policy", "default-src 'self' https:; "+
+		"style-src 'self' 'unsafe-inline' https:; "+
+		"script-src 'self' 'unsafe-eval' https://cdnjs.cloudflare.com https://www.google-analytics.com; "+
+		"frame-ancestors 'none'")*/
+
+	header.Add(cache.CacheControlHeader, cache.StaticContentOptions)
+
+	// Fastly cache header
+	header.Add(fastly.SurrogateControlHeader, cache.SurrogateStaticContentOptions)
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.3.2",
     "gulp-uglify": "^2.0.0",
-    "vue-loader": "^9.7.0",
+    "vue-loader": "^10.0.1",
+    "vue-template-compiler": "^2.1.3",
     "webpack": "^2.1.0-beta.25"
   },
   "scripts": {

--- a/spongehome.go
+++ b/spongehome.go
@@ -26,63 +26,42 @@
 package main // import "github.com/SpongePowered/SpongeHome"
 
 import (
-	"fmt"
 	"github.com/SpongePowered/SpongeHome/controllers"
+	"github.com/SpongePowered/SpongeWebGo/fastly"
 	"github.com/go-macaron/gzip"
 	"github.com/go-macaron/pongo2"
-	"github.com/sethvargo/go-fastly"
 	"gopkg.in/macaron.v1"
+	"log"
 	"os"
-	"time"
 )
 
-func clearFastly() {
-	// Clear Fastly cache
-	if os.Getenv("FASTLY_KEY") != "" {
-		time.Sleep(10 * time.Second) // Let the http server startup
-		fmt.Println("starting fastly client")
-		client, err := fastly.NewClient(os.Getenv("FASTLY_KEY"))
-		if err != nil {
-			fmt.Println(err)
-			return
-		}
-		services, err := client.ListServices(&fastly.ListServicesInput{})
-		fastlyService := ""
-		if os.Getenv("SPONGE_ENV") == "prod" {
-			fastlyService = "www.spongepowered.org"
-		} else if os.Getenv("SPONGE_ENV") == "staging" {
-			fastlyService = "www-staging.spongepowered.org"
-		} else if os.Getenv("SPONGE_ENV") == "" {
-			fmt.Println("SPONGE_ENV is not set")
-			return
-		}
-		for _, svc := range services {
-			if svc.Name == fastlyService {
-				_, err := client.PurgeAll(&fastly.PurgeAllInput{
-					Service: svc.ID,
-					Soft:    false,
-				})
-				if err != nil {
-					fmt.Println("fastly cache purge failed")
-					fmt.Println(err)
-					return
-				} else {
-					fmt.Println("found match and purged")
-				}
-			}
-		}
-		fmt.Println("Finished clearing Fastly cache")
-	}
-}
-
 func main() {
+	var c *fastly.Cache
+	if fastlyConfig := os.Getenv("FASTLY_CACHE"); fastlyConfig != "" {
+		var err error
+		c, err = fastly.ParseConfig(log.New(os.Stdout, "[Fastly] ", log.LstdFlags), fastlyConfig)
+		if err != nil {
+			log.Fatalln(err)
+		}
+	}
+
 	// Initialise Macaron
 	m := macaron.New()
-	m.Use(pongo2.Pongoer())
-	m.Use(macaron.Logger())
+
+	if c != nil {
+		// Hide Fastly health checks from log
+		m.Use(c.LogHandler())
+	} else {
+		m.Use(macaron.Logger())
+	}
+
 	m.Use(macaron.Recovery())
+
+	m.Use(pongo2.Pongoer())
 	m.Use(gzip.Gziper())
 	m.Use(macaron.Static("public"))
+
+	m.Use(controllers.AddHeaders)
 
 	// Routes
 	m.Get("/", controllers.GetHomepage)
@@ -97,7 +76,10 @@ func main() {
 	m.Get("/downloads", controllers.GetDownloads)
 	m.Get("/downloads/*", controllers.GetDownloads)
 
-	go clearFastly()
+	if c != nil {
+		// Attempt to purge fastly cache
+		go c.PurgeAll()
+	}
 
 	// Run SpongeHome
 	m.Run()

--- a/templates/base.html
+++ b/templates/base.html
@@ -36,13 +36,13 @@ THE SOFTWARE.
     <link rel="icon" type="image/png" href="https://forums-cdn.spongepowered.org/uploads/default/original/2X/9/9ba706a80e45cf427617525ee2a19fad7bb6b109.png">
 
     <!-- Bootstrap Core CSS - Uses Bootswatch Flatly Theme: https://bootswatch.com/flatly/ -->
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/flatly/bootstrap{{ min }}.css" rel="stylesheet" />
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/flatly/bootstrap{{ min }}.css" rel="stylesheet" {%if min%}integrity="sha256-r1WijW/SNMgOwk5LDk7QRHr6oVYYbYWMw/1kOXfYJfg="{%endif%} crossorigin="anonymous" />
 
     <!-- Custom CSS -->
     <link href="/assets/css/spongehome{{ min }}.css" rel="stylesheet">
 
     <!-- Custom Fonts -->
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome{{ min }}.css" rel="stylesheet" />
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome{{ min }}.css" rel="stylesheet" {%if min%}integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0="{%endif%} crossorigin="anonymous" />
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet">
 </head>
 <body id="{{ page }}-page">
@@ -136,13 +136,13 @@ THE SOFTWARE.
 </footer>
 
 <!-- jQuery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery{{ min }}.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery{{ min }}.js" {%if min%}integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8="{%endif%} crossorigin="anonymous"></script>
 
 <!-- Bootstrap Core JavaScript -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap{{ min }}.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap{{ min }}.js" {%if min%}integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8="{%endif%} crossorigin="anonymous"></script>
 
 <!-- Plugin JavaScript -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.3/jquery.easing.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.3/jquery.easing.min.js" {%if min%}integrity="sha256-rD86dXv7/J2SvI9ebmNi5dSuQdvzzrrN2puPca/ILls="{%endif%} crossorigin="anonymous"></script>
 
 <!-- Custom Theme JavaScript -->
 <script src="/assets/js/spongehome{{ min }}.js"></script>

--- a/templates/downloads.html
+++ b/templates/downloads.html
@@ -58,6 +58,6 @@ THE SOFTWARE.
 {% endblock %}
 
 {% block vue_javascript %}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/vue-router/2.0.3/vue-router{{ min }}.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.17.0/moment{{ min }}.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/vue-router/2.0.3/vue-router{{ min }}.js" {%if min%}integrity="sha256-FasqH+B0Sw9thkvdI9USAL3mZVOu0dy4CCxtKKVNkhA="{%endif%} crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.17.0/moment{{ min }}.js" {%if min%}integrity="sha256-Q1iNs8Pv5aDBQqByxUM4pQmdzbPFyNooDFJKojYnVpg="{%endif%} crossorigin="anonymous"></script>
 {% endblock %}

--- a/templates/downloads.html
+++ b/templates/downloads.html
@@ -35,7 +35,7 @@ THE SOFTWARE.
 
 {% block content %}
 <div v-if="loadingVue">
-    <header id="downloads">
+    <header>
         <div class="container">
             <div class="logo">
                 <img src="/assets/img/icons/spongie-mark-reverse-dark.svg" />

--- a/templates/downloads.html
+++ b/templates/downloads.html
@@ -59,5 +59,5 @@ THE SOFTWARE.
 
 {% block vue_javascript %}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/vue-router/2.0.3/vue-router{{ min }}.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.16.0/moment{{ min }}.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.17.0/moment{{ min }}.js"></script>
 {% endblock %}

--- a/templates/vue.html
+++ b/templates/vue.html
@@ -26,7 +26,7 @@ THE SOFTWARE.
 {% extends "base.html" %}
 
 {% block javascript %}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.0.7/vue{{ min }}.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.1.3/vue{{ min }}.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/vue-resource/1.0.3/vue-resource{{ min }}.js"></script>
 {% block vue_javascript %}{% endblock %}
 <script src="/assets/js/{{ page }}{{ min }}.js"></script>

--- a/templates/vue.html
+++ b/templates/vue.html
@@ -26,8 +26,8 @@ THE SOFTWARE.
 {% extends "base.html" %}
 
 {% block javascript %}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.1.3/vue{{ min }}.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/vue-resource/1.0.3/vue-resource{{ min }}.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.1.3/vue{{ min }}.js" {%if min%}integrity="sha256-r+wmZoP04ZrX/3jL7lpfcXD/eWGByabfL8IIJ/NuGeA="{%endif%} crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/vue-resource/1.0.3/vue-resource{{ min }}.js" {%if min%}integrity="sha256-r1pzeA1LCRPQD9oeuNDP4T8ftytq7waSglmmISCfE9I="{%endif%} crossorigin="anonymous"></script>
 {% block vue_javascript %}{% endblock %}
 <script src="/assets/js/{{ page }}{{ min }}.js"></script>
 {% endblock %}


### PR DESCRIPTION
Should fix #118 by adding the proper cache headers which should make Fastly cache the website for a month (if not purged manually). It should also serve the cached content for an additional week if an error occurs.

I've changed SpongeDownloads and SpongeHome to use the same system for purging the fastly cache, which is in https://github.com/SpongePowered/SpongeWebGo. When configured correctly, it can be also used to hide Fastly's health checks from the log (prevents a lot of spam).

For SpongeHome, it uses an environment variable `FASTLY_CACHE` with the same format as on SpongeDownloads (just without the `fastly:` prefix):
`API_KEY/SERVICE_ID[;healthcheck]`. The `healthcheck` option is optional.

In SpongeGoWeb, I've also made some changes suggested by https://observatory.mozilla.org/analyze.html?host=www.spongepowered.org:

- Added some headers (they don't break anything)
- ~~Added the [`Content-Security-Policy` header](https://wiki.mozilla.org/Security/Guidelines/Web_Security#Content_Security_Policy). Because of the announcements and our usage of Vue it is quite permissive currently, we can improve it later.~~ (Disabled it for now because it needs more testing)
- Added [subresource integrity](https://wiki.mozilla.org/Security/Guidelines/Web_Security#Subresource_Integrity), only used in production because we use the non-minified files in development environment .