### PR TITLE
Improvements for downloads page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js: 6
 
 env:
   global:
-    - GIMME_GO_VERSION=1.7.3
+    - GIMME_GO_VERSION=1.7.4
     - GOPATH=$HOME/go
     - GO_PROJECT=github.com/SpongePowered/SpongeHome
     - GO_PROJECT_DIR=$GOPATH/src/$GO_PROJECT

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "license": "MIT",
   "devDependencies": {
     "autoprefixer": "^6.5.1",
-    "buble": "^0.14.2",
-    "buble-loader": "^0.3.2",
+    "buble": "^0.15.1",
+    "buble-loader": "^0.4.0",
     "core-js": "^2.4.1",
     "css-loader": "^0.26.0",
     "gulp": "^3.9.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "gulp-nunjucks-render": "git+https://github.com/mohitsinghs/gulp-nunjucks-render.git",
     "gulp-postcss": "^6.2.0",
     "gulp-rename": "^1.2.2",
-    "gulp-sass": "^2.3.2",
+    "gulp-sass": "^3.0.0",
     "gulp-uglify": "^2.0.0",
     "vue-loader": "^10.0.1",
     "vue-template-compiler": "^2.1.3",

--- a/src/html/downloads.html
+++ b/src/html/downloads.html
@@ -59,6 +59,6 @@
 {% endblock %}
 
 {% block vue_javascript %}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/vue-router/2.0.3/vue-router{{ min }}.js" {%if min%}integrity="sha256-FasqH+B0Sw9thkvdI9USAL3mZVOu0dy4CCxtKKVNkhA="{%endif%} crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.17.0/moment{{ min }}.js" {%if min%}integrity="sha256-Q1iNs8Pv5aDBQqByxUM4pQmdzbPFyNooDFJKojYnVpg="{%endif%} crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/vue-router/2.1.1/vue-router{{ min }}.js" {%if min%}integrity="sha256-oueP7OWdjxn2yahCeNT3W72eHGAYCHfEX3m1OPR3Dyk="{%endif%} crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.17.1/moment{{ min }}.js" {%if min%}integrity="sha256-Gn7MUQono8LUxTfRA0WZzJgTua52Udm1Ifrk5421zkA="{%endif%} crossorigin="anonymous"></script>
 {% endblock %}

--- a/src/html/include/vue.html
+++ b/src/html/include/vue.html
@@ -26,7 +26,7 @@
 {% extends "include/base.html" %}
 
 {% block javascript %}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.1.3/vue{{ min }}.js" {%if min%}integrity="sha256-r+wmZoP04ZrX/3jL7lpfcXD/eWGByabfL8IIJ/NuGeA="{%endif%} crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.1.4/vue{{ min }}.js" {%if min%}integrity="sha256-7rvZ8brPuQuaC9GzcDQIheBFtmJSGg9S/MndBv24GtQ="{%endif%} crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/vue-resource/1.0.3/vue-resource{{ min }}.js" {%if min%}integrity="sha256-r1pzeA1LCRPQD9oeuNDP4T8ftytq7waSglmmISCfE9I="{%endif%} crossorigin="anonymous"></script>
 {% block vue_javascript %}{% endblock %}
 <script src="/assets/js/{{ page }}{{ min }}.js"></script>

--- a/src/html/include/vue.html
+++ b/src/html/include/vue.html
@@ -26,7 +26,7 @@
 {% extends "include/base.html" %}
 
 {% block javascript %}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.1.4/vue{{ min }}.js" {%if min%}integrity="sha256-7rvZ8brPuQuaC9GzcDQIheBFtmJSGg9S/MndBv24GtQ="{%endif%} crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.1.6/vue{{ min }}.js" {%if min%}integrity="sha256-WcJDyxpvFLMHHA7kQuvbE5kWgRwV3zukWdjvbTUcXh8="{%endif%} crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/vue-resource/1.0.3/vue-resource{{ min }}.js" {%if min%}integrity="sha256-r1pzeA1LCRPQD9oeuNDP4T8ftytq7waSglmmISCfE9I="{%endif%} crossorigin="anonymous"></script>
 {% block vue_javascript %}{% endblock %}
 <script src="/assets/js/{{ page }}{{ min }}.js"></script>

--- a/src/js/downloads/Builds.vue
+++ b/src/js/downloads/Builds.vue
@@ -43,6 +43,7 @@
                     <span v-else>No changelog available.</span>
                 </div>
             </div>
+
             <div class="clearfix"></div>
         </li>
     </ol>

--- a/src/js/downloads/Builds.vue
+++ b/src/js/downloads/Builds.vue
@@ -26,7 +26,7 @@
 <template>
     <ol class="builds">
         <li v-for="build in builds" class="build" :id="build.version">
-            <h4>{{ build.version }} <span v-for="label in build.labels" :class="['label', 'label-' + label.color]">{{ label.name }}</span></h4>
+            <h4>{{ build.version }} <build-label v-for="label in build.labels" :l="label"></build-label></h4>
 
             <div class="artifacts">
                 <a v-for="artifact in build.artifacts" :href="artifact.url" :title="artifact.type.title"
@@ -50,6 +50,7 @@
 
 <script>
     import RelativeTime from 'downloads/relative-time'
+    import BuildLabel from 'downloads/build-label'
     import Commits from 'downloads/Commits.vue'
 
     export default {
@@ -69,6 +70,7 @@
         },
         components: {
             'relative-time': RelativeTime,
+            'build-label': BuildLabel,
             commits: Commits
         }
     }

--- a/src/js/downloads/Commits.vue
+++ b/src/js/downloads/Commits.vue
@@ -23,21 +23,29 @@
     THE SOFTWARE.
 -->
 
+<!--suppress XmlUnboundNsPrefix -->
 <template>
     <ol class="commits">
-        <li class="commit" v-for="commit in l">
+        <li class="commit" v-for="commit in commits">
             <a :href="'https://github.com/SpongePowered/' + project + '/commit/' + commit.id" target="_blank">{{ commit.title }}</a>
             <button class="ellipsis-expander" data-toggle="collapse-next" v-if="commit.description || commit.submodules">…</button>
             <div>{{ commit.author }} - <small><relative-time :t="commit.date"></relative-time></small></div>
             <div class="collapse" v-if="commit.description || commit.submodules">
                 <pre class="commit-message" v-if="commit.description">{{ commit.description }}</pre>
                 <div class="commit-submodules" v-if="commit.submodules">
-                    <div v-for="(commits, submodule) in commit.submodules">
-                        <h5>{{ submodule }}</h5>
-                        <commits :project="submodule" :l="commits"></commits>
+                    <div v-for="(subcommits, submodule) in commit.submodules">
+                        <!-- TODO: Submodule commits should be NEVER null -->
+                        <template v-if="subcommits">
+                            <h5>{{ submodule }}</h5>
+                            <commits :project="submodule" :l="subcommits"></commits>
+                        </template>
                     </div>
                 </div>
             </div>
+        </li>
+
+        <li v-if="count < l.length" class="more-commits">
+            <a v-on:click="count *= 2">Show {{ l.length - count }} older commits.</a>
         </li>
     </ol>
 </template>
@@ -48,6 +56,20 @@
     export default {
         name: 'commits',
         props: ['project', 'l'],
+        data() {
+            return {
+                count: 5
+            }
+        },
+        computed: {
+            commits() {
+                if (this.count >= this.l.length) {
+                    return this.l
+                } else {
+                    return this.l.slice(0, this.count)
+                }
+            }
+        },
         components: {
             'relative-time': RelativeTime
         }

--- a/src/js/downloads/Downloads.vue
+++ b/src/js/downloads/Downloads.vue
@@ -188,7 +188,7 @@
 
                         buildTypesData[type.id] = buildTypeData;
 
-                        const category = this.platform.category.forBuildType(data.latest);
+                        const category = this.platform.category.forBuild(data.latest);
                         if (category) {
                             buildTypeData.categoryVersion = category;
                             currentCategoryVersions.add(category);
@@ -275,6 +275,7 @@
                             }
                         }
 
+                        this.platform.addLabels && this.platform.addLabels(build);
                         this.readArtifacts(build)
                     }
 

--- a/src/js/downloads/Downloads.vue
+++ b/src/js/downloads/Downloads.vue
@@ -50,12 +50,14 @@
                         <router-link v-for="version of platform.category.versions.current"
                                      :to="routeForCategory(version)"
                                      class="btn btn-primary">{{ version }}</router-link>
-                        <a aria-expanded="false" href="#" class="btn btn-primary dropdown-toggle" data-toggle="dropdown"><span class="caret"></span></a>
-                        <ul class="dropdown-menu dropdown-menu-right">
-                            <li v-for="version of platform.category.versions.unsupported">
-                                <router-link :to="routeForCategory(version)">{{ version }}</router-link>
-                            </li>
-                        </ul>
+                        <template v-if="platform.category.versions.unsupported.length > 0">
+                            <a aria-expanded="false" href="#" class="btn btn-primary dropdown-toggle" data-toggle="dropdown"><span class="caret"></span></a>
+                            <ul class="dropdown-menu dropdown-menu-right">
+                                <li v-for="version of platform.category.versions.unsupported">
+                                    <router-link :to="routeForCategory(version)">{{ version }}</router-link>
+                                </li>
+                            </ul>
+                        </template>
                     </div>
                 </div>
             </div>

--- a/src/js/downloads/Downloads.vue
+++ b/src/js/downloads/Downloads.vue
@@ -167,8 +167,8 @@
 
                     const buildTypes = [], buildTypesData = {};
 
-                    const currentCategoryVersions = new Set();
-                    const unsupportedCategoryVersions = new Set(this.platform.category.forProject(project));
+                    const currentCategoryVersions = new Set(this.platform.category.forProject(project));
+                    const unsupportedCategoryVersions = new Set(currentCategoryVersions);
 
                     for (const type of BuildTypes) {
                         if (!type.id in project.buildTypes) {
@@ -191,9 +191,14 @@
                         const category = this.platform.category.forBuild(data.latest);
                         if (category) {
                             buildTypeData.categoryVersion = category;
-                            currentCategoryVersions.add(category);
                             unsupportedCategoryVersions.delete(category);
                         }
+                    }
+
+                    const unsupportedCategoryVersionsArray = Array.from(unsupportedCategoryVersions);
+
+                    for (const version of unsupportedCategoryVersionsArray) {
+                        currentCategoryVersions.delete(version)
                     }
 
                     this.platform.buildTypes = buildTypes;
@@ -201,7 +206,7 @@
                     // Vue does not support iterating over sets currently, https://github.com/vuejs/vue/issues/2410
                     this.platform.category.versions = {
                         current: Array.from(currentCategoryVersions),
-                        unsupported: Array.from(unsupportedCategoryVersions)
+                        unsupported: unsupportedCategoryVersionsArray
                     };
 
                     this.platform.buildTypesData = buildTypesData;

--- a/src/js/downloads/Platforms.vue
+++ b/src/js/downloads/Platforms.vue
@@ -41,14 +41,12 @@
 <script>
     import {Platforms} from 'downloads/platforms'
 
-    const data = {
-        platforms: Platforms
-    };
-
     export default {
         name: 'platforms',
         data() {
-            return data
+            return {
+                platforms: Platforms
+            }
         }
     }
 </script>

--- a/src/js/downloads/build-label.js
+++ b/src/js/downloads/build-label.js
@@ -24,16 +24,18 @@
  */
 
 export default {
-    name: 'relative-time',
+    name: 'build-label',
     props: {
-        t: String,
-        tag: {
-            type: String,
-            default: 'span'
-        }
+        l: Object
     },
     render(create) {
-        const m = moment(this.t);
-        return create(this.tag, {attrs:{title: m.local().format("LLL")}}, m.fromNow())
+        return create(this.l.link ? 'a' : 'span', {
+            class: ['label', `label-${this.l.color}`],
+            attrs: {
+                title: this.l.title,
+                href: this.l.link,
+                target: this.l.link && '_blank'
+            }
+        }, this.l.name)
     }
 }

--- a/src/js/downloads/platforms.js
+++ b/src/js/downloads/platforms.js
@@ -115,7 +115,19 @@ export const Platforms = {
             ArtifactTypes.Main,
             ArtifactTypes.Sources,
             ArtifactTypes.DevShaded
-        ]
+        ],
+        addLabels(build) {
+            const minecraftVersion = this.category.forBuild(build);
+            const forgeVersion = build.dependencies.forge;
+            if (forgeVersion) {
+                build.labels.push({
+                    name: `Forge ${forgeVersion.split('.')[3]}`,
+                    color: 'forge',
+                    title: "Recommended Forge version",
+                    link: `http://files.minecraftforge.net/maven/net/minecraftforge/forge/index_${minecraftVersion}.html`
+                })
+            }
+        }
     },
     spongeapi: {
         group: 'org.spongepowered',
@@ -130,7 +142,7 @@ export const Platforms = {
             extractVersion(version) {
                 return version.split('.')[0]
             },
-            forBuildType(build) {
+            forBuild(build) {
                 return this.extractVersion(build.version)
             },
             forProject(project) {
@@ -149,7 +161,7 @@ function createDependencyCategory(dependency, name) {
     return {
         name: name,
         id: dependency,
-        forBuildType(build) {
+        forBuild(build) {
             return build.dependencies[this.id]
         },
         forProject(project) {

--- a/src/scss/_downloads.scss
+++ b/src/scss/_downloads.scss
@@ -175,6 +175,14 @@ router-link {
   }
 }
 
+.label-forge {
+  background-color: #910020;
+
+  &:hover {
+    background-color: darken(#910020, 5%)
+  }
+}
+
 #build-types {
   padding: 0;
   font-size: 19px;

--- a/src/scss/_downloads.scss
+++ b/src/scss/_downloads.scss
@@ -371,7 +371,7 @@ router-link {
 .commit {
   margin-bottom: 5px;
 
-  a {
+  &> a {
     color: $sponge_dark_grey;
     font-weight: bold;
     word-wrap: break-word;
@@ -417,5 +417,11 @@ router-link {
 
   h5 {
     margin-bottom: 8px;
+  }
+}
+
+.more-commits {
+  a {
+    cursor: pointer;
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,6 +61,10 @@ function extendConfig(env, config) {
 exports.dev = extendConfig('development', {
     devtool: 'eval',
 
+    performance: {
+        hints: false
+    },
+
     output: {
         path: __dirname + '/dist/dev/assets/js',
         filename: '[name].js',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -99,7 +99,7 @@ function createServerConfig() {
             .concat(config.entry[key])
     }
 
-    config.plugins = config.plugins.concat(new webpack.HotModuleReplacementPlugin());
+    config.plugins = config.plugins.concat(new webpack.HotModuleReplacementPlugin(), new webpack.NamedModulesPlugin());
     return config
 }
 


### PR DESCRIPTION
I've implemented some minor changes / additions requested by @Zidane and a few others:

- Display Forge version as label for each SpongeForge build (with a link to the Forge downloads page)
- Fixed the order of the Minecraft version (`1.11` comes before `1.10.2` now)
- Limit changelog to five commits with a link to show more. Makes the page more clean with huge changelogs and should improve performance since they are not even rendered until requested.

Other changes:
- Hide dropdown for Minecraft versions on SpongeForge as long it is empty
- Other minor fixes / dependency upgrades

## Demo
Available at https://sponge.dev.minecrell.net/downloads/spongeforge

![screen shot 2016-12-12 at 19 12 33](https://cloud.githubusercontent.com/assets/3035868/21110801/fa6d6306-c09e-11e6-9de9-cb5d56ea2f48.png)
