### PR TITLE
[WIP] Remove build type selection and other improvements for downloads page

### DIFF
--- a/src/js/downloads.js
+++ b/src/js/downloads.js
@@ -40,13 +40,8 @@ const routes = [
         component: Downloads
     },
     {
-        name: 'downloads-build-type',
-        path: '/downloads/:project/:buildType',
-        component: Downloads
-    },
-    {
         name: 'downloads',
-        path: '/downloads/:project/:buildType/:category',
+        path: '/downloads/:project/:category',
         component: Downloads
     }
 ];

--- a/src/js/downloads/platforms.js
+++ b/src/js/downloads/platforms.js
@@ -25,18 +25,23 @@
 
 export const API = process.env.DOWNLOADS_API_URL || "https://dl-api.spongepowered.org";
 
-export const BuildTypes = [
-    {
+export const BuildTypes = {
+    stable: {
         name: "Stable",
         id: 'stable',
         color: 'primary'
     },
-    {
+    bleeding: {
         name: "Experimental",
         id: 'bleeding',
         color: 'warning'
+    },
+    unstable: {
+        name: "Unstable",
+        id: 'unstable',
+        color: 'danger'
     }
-];
+};
 
 export const Labels = {
     recommended: {
@@ -49,10 +54,10 @@ export const Labels = {
         color: 'success',
         title: "Latest build"
     },
-    /*unsupported: {
+    unsupported: {
         name: "Unsupported",
         color: 'danger'
-    }*/
+    }
 };
 
 const ArtifactTypes = {

--- a/src/js/downloads/version-comparator.js
+++ b/src/js/downloads/version-comparator.js
@@ -1,0 +1,15 @@
+export default function(a, b) {
+    const aa = a.split('.');
+    const ba = b.split('.');
+
+    const max = Math.max(a.length, b.length);
+
+    for (let i = 0; i < max; ++i) {
+        const result = parseInt(aa[i], 10) - parseInt(ba[i], 10);
+        if (result !== 0) {
+            return result;
+        }
+    }
+
+    return a.length - b.length
+}


### PR DESCRIPTION
The build type selection makes navigation extremely confusing, and it is actually only useful if stable and bleeding target the same Minecraft versions. In all other cases, the latest build will always be the right one.

The primary change in this PR is the removal of the build type selection. Navigation is much easier by using only the Minecraft version (or the API version for SpongeAPI). It also properly supports multiple stable branches now.

I have a few more minor improvements planned for this PR and I will update this description as soon as they're implemented.

### Demo page
Available at https://sponge.dev.minecrell.net/downloads/spongevanilla (Only SpongeVanilla is working on this test page)