### PR TITLE
Rework the chat page to support either IRC or Discord.

### DIFF
--- a/src/html/chat.html
+++ b/src/html/chat.html
@@ -68,7 +68,7 @@
             <a href="https://discord.gg/PtaGRAs">Click here</a> to join the SpongePowered Discord server.
         </p>
         <p>
-            <img src="https://discordapp.com/assets/e4923594e694a21542a489471ecffa50.svg" alt="" height=100>
+            <a href="https://discord.gg/PtaGRAs"><img src="https://discordapp.com/assets/e4923594e694a21542a489471ecffa50.svg" alt="" height=100></a>
         </p>
     </section>
 </div>

--- a/src/html/chat.html
+++ b/src/html/chat.html
@@ -33,7 +33,40 @@
 {% endblock %}
 
 {% block content %}
-<div id="chat-wrapper">
-    <iframe id="chat-frame" src="https://kiwiirc.com/client/irc.esper.net:+6697/?nick=sponge|?#sponge"></iframe>
+<header>
+    <div class="container">
+        <div class="logo">
+            <img src="assets/img/icons/spongie-mark-reverse-dark.svg" alt="">
+            <h1>Sponge</h1>
+        </div>
+        <h2>Chat</h2>
+    </div>
+</header>
+
+<div class="container chat-content">
+    <section id="chat-overview">
+        <p>
+            SpongePowered provides several IRC channels and a Discord server for you to discuss the Sponge project on.
+            The IRC channels and Discord server are linked, so feel free to use either.
+        </p>
+    </section>
+
+    <section id="chat-irc">
+        <h3>IRC</h3>
+        <p>
+            The official Sponge channels are <code>#sponge</code>, <code>#spongedev</code>, and <code>#spongedocs</code> on <a href="irc://irc.esper.net:6667">irc.esper.net</a>.
+        </p>
+
+        <p>
+            If you don't have an IRC client installed, you can <a href="https://kiwiirc.com/client/irc.esper.net:+6697/?nick=sponge|?#sponge" target="_blank">use the web client</a>.
+        </p>
+    </section>
+
+    <section id="chat-discord">
+        <h3>Discord</h3>
+        <p>
+            <a href="https://discord.gg/PtaGRAs">Click here</a> to join the SpongePowered Discord server.
+        </p>
+    </section>
 </div>
 {% endblock %}

--- a/src/html/chat.html
+++ b/src/html/chat.html
@@ -36,7 +36,7 @@
 <header>
     <div class="container">
         <div class="logo">
-            <img src="assets/img/icons/spongie-mark-dark.svg" alt="">
+            <img src="assets/img/icons/spongie-mark-dark.svg">
             <h1>Sponge</h1>
         </div>
         <h2>Chat</h2>
@@ -68,7 +68,7 @@
             <a href="https://discord.gg/PtaGRAs">Click here</a> to join the SpongePowered Discord server.
         </p>
         <p>
-            <a href="https://discord.gg/PtaGRAs"><img src="https://discordapp.com/assets/e4923594e694a21542a489471ecffa50.svg" alt="" height=100></a>
+            <a href="https://discord.gg/PtaGRAs"><img src="https://discordapp.com/assets/e4923594e694a21542a489471ecffa50.svg" height=100></a>
         </p>
     </section>
 </div>

--- a/src/html/chat.html
+++ b/src/html/chat.html
@@ -68,7 +68,7 @@
             <a href="https://discord.gg/PtaGRAs">Click here</a> to join the SpongePowered Discord server.
         </p>
         <p>
-            <img src="https://discordapp.com/assets/e4923594e694a21542a489471ecffa50.svg" alt="" height=64>
+            <img src="https://discordapp.com/assets/e4923594e694a21542a489471ecffa50.svg" alt="" height=100>
         </p>
     </section>
 </div>

--- a/src/html/chat.html
+++ b/src/html/chat.html
@@ -36,7 +36,7 @@
 <header>
     <div class="container">
         <div class="logo">
-            <img src="assets/img/icons/spongie-mark-reverse-dark.svg" alt="">
+            <img src="assets/img/icons/spongie-mark-dark.svg" alt="">
             <h1>Sponge</h1>
         </div>
         <h2>Chat</h2>
@@ -66,6 +66,9 @@
         <h3>Discord</h3>
         <p>
             <a href="https://discord.gg/PtaGRAs">Click here</a> to join the SpongePowered Discord server.
+        </p>
+        <p>
+            <img src="https://discordapp.com/assets/e4923594e694a21542a489471ecffa50.svg" alt="" height=64>
         </p>
     </section>
 </div>

--- a/src/scss/_chat.scss
+++ b/src/scss/_chat.scss
@@ -24,35 +24,41 @@
  */
 
 #chat-page {
-  footer {
-    position: absolute;
+  header {
+    margin-top: 50px;
+    padding-bottom: 20px;
 
-    top: 100%;
-    left: 0;
-    right: 0;
-    bottom: 0;
+    .logo {
+      display: block;
+      white-space: nowrap;
+      overflow: hidden;
 
-    width: 100%;
+      @media (max-width: 767px) {
+        font-size: 3vmin;
+      }
+
+      &> * {
+        display: inline-block;
+        vertical-align: middle;
+
+        margin: 0;
+        padding: 0;
+      }
+
+      img {
+        height: 8em;
+      }
+
+      h1 {
+        font-size: 4.5em;
+        margin-left: 20px;
+      }
+    }
   }
-}
 
-#chat-wrapper {
-  margin-top: $sp_topbar_height;
+  .chat-content {
+    padding-top: 30px;
+    padding-bottom: 40px;
+  }
 
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-}
-
-#chat-frame {
-  display: block;
-
-  border: 0;
-  margin: 0;
-  padding: 0;
-
-  width: 100%;
-  height: 100%;
 }


### PR DESCRIPTION
Since Sponge now has an official Discord server, I've seen quite a few cases where someone joins the IRC server only to grab the Discord link and leave. I reworked the chat page to show both the IRC and Discord options.