### PR TITLE
Fix image alignment and hide meta in announcements

### DIFF
--- a/src/scss/_index_sections.scss
+++ b/src/scss/_index_sections.scss
@@ -76,6 +76,15 @@
       font-size: 1.2em;
     }
 
+    img {
+      max-width: 100%;
+      max-height: 100%;
+    }
+
+    .meta {
+      display: none;
+    }
+
     .emoji {
       height: 1.1em;
     }


### PR DESCRIPTION
_FLARDCoin blew up the alignment here. I will attempt to safely compress it a little without making it more volatile._

Before:
![before](https://user-images.githubusercontent.com/12867785/38218606-75c653ec-3726-11e8-813b-f75f329ce697.PNG)

After:
![after](https://user-images.githubusercontent.com/12867785/38218616-7c308496-3726-11e8-8b60-85f71e34fdbc.PNG)

