### PR TITLE
Use Eyeglass for importing Bootstrap and Bootswatch

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,12 +9,31 @@ const
     sass = require('gulp-sass'),
     postcss = require('gulp-postcss'),
     autoprefixer = require('autoprefixer'),
+    eyeglass = require("eyeglass"),
 
     htmlmin = require('gulp-htmlmin'),
     uglify = require('gulp-uglify'),
     cleanCSS = require('gulp-clean-css');
 
 const sponsors = require('./sponsors.json');
+
+const sassOptions = {
+    eyeglass: {
+        modules: [
+            {
+                name: "bootswatch",
+                main: function(eyeglass, sass) {
+                    return {
+                        sassDir: "node_modules/bootswatch/"
+                    }
+                },
+                eyeglass: {
+                    needs: "^2.4.1"
+                }
+            }
+        ]
+    }
+};
 
 function htmlData(file) {
     const name = path.basename(file.path, '.html');
@@ -65,7 +84,7 @@ function html() {
 
 function scss() {
     return gulp.src('./src/scss/spongehome.scss')
-        .pipe(sass().on('error', sass.logError))
+        .pipe(sass(eyeglass(sassOptions)).on('error', sass.logError))
         .pipe(postcss([
             autoprefixer()
         ]))

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   "license": "MIT",
   "devDependencies": {
     "autoprefixer": "^9.6.1",
+    "bootstrap-sass": "^3.4.1",
+    "bootswatch": "^3.4.1",
+    "eyeglass": "^2.4.1",
     "gulp": "^4.0.2",
     "gulp-clean-css": "^4.2.0",
     "gulp-data": "^1.2.1",

--- a/src/html/include/base.html
+++ b/src/html/include/base.html
@@ -37,12 +37,11 @@
     <title>{{ title }}</title>
     <link rel="icon" href="favicon.ico">
 
-    <!-- Custom CSS -->
+    <!-- Sponge Stylesheets -->
     <link href="assets/css/spongehome{{ min }}.css" rel="stylesheet">
 
     <!-- Custom Fonts -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.9.0/css/all{{ min }}.css" {%if min%}integrity="sha384-i1LQnF23gykqWXg6jxC2ZbCbUMxyw5gLZY6UiUS98LYV5unm8GWmfkIS6jqJfb4E"{%endif%} crossorigin="anonymous">
-    <link href="https://fonts.googleapis.com/css?family=Montserrat:400,500,600,700" rel="stylesheet">
 </head>
 <body id="{{ page }}-page">
 <div id="top"></div>

--- a/src/html/include/base.html
+++ b/src/html/include/base.html
@@ -37,9 +37,6 @@
     <title>{{ title }}</title>
     <link rel="icon" href="favicon.ico">
 
-    <!-- Bootstrap Core CSS - Uses Bootswatch Flatly Theme: https://bootswatch.com/flatly/ -->
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/flatly/bootstrap{{ min }}.css" rel="stylesheet" {%if min%}integrity="sha256-r1WijW/SNMgOwk5LDk7QRHr6oVYYbYWMw/1kOXfYJfg="{%endif%} crossorigin="anonymous" />
-
     <!-- Custom CSS -->
     <link href="assets/css/spongehome{{ min }}.css" rel="stylesheet">
 

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -76,22 +76,3 @@ h3 {
 h4, h5, h6 {
   font-weight: 500;
 }
-
-.btn {
-  &:focus, &:active, &.active {
-    outline: 0;
-  }
-}
-
-.btn-outline {
-  background: none;
-  color: #fff;
-  margin-top: 15px;
-  border: solid 2px #fff;
-  transition: all .3s ease-in-out;
-
-  &:hover, &:focus, &:active, &.active {
-    color: $sponge_yellow;
-    background-color: white;
-  }
-}

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -64,11 +64,17 @@ a {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  @extend .sponge-headline;
+  @include montserrat;
+  @include uppercase;
+  font-weight: 700;
 }
 
-h3, h4, h5, h6 {
+h3 {
   font-weight: 600;
+}
+
+h4, h5, h6 {
+  font-weight: 500;
 }
 
 .btn {

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -23,6 +23,9 @@
  * THE SOFTWARE.
  */
 
+@import "variables";
+@import "mixins/font";
+
 html, body {
   height: 100%;
 }
@@ -34,11 +37,8 @@ html, body {
 }
 
 body {
-  color: $sponge_grey;
-
   position: relative;
   overflow-x: hidden;
-  margin: 0 auto;
 }
 
 p {

--- a/src/scss/_buttons.scss
+++ b/src/scss/_buttons.scss
@@ -23,6 +23,8 @@
  * THE SOFTWARE.
  */
 
+@import "variables";
+
 .btn {
   transition: all .3s ease-in-out;
 }

--- a/src/scss/_buttons.scss
+++ b/src/scss/_buttons.scss
@@ -27,6 +27,10 @@
 
 .btn {
   transition: all .3s ease-in-out;
+
+  &:focus, &:active, &.active {
+    outline: 0;
+  }
 }
 
 .btn-primary {
@@ -38,27 +42,37 @@
     color: $sponge_grey;
     border: 1px solid $sponge_dark_yellow;
   }
-}
 
-.btn-primary.current {
-  background-color: $sponge_yellow;
-  color: $sponge_grey;
-  border: 1px solid $sponge_dark_yellow;
-  transition: all .3s ease-in-out;
-  font-weight: bold;
+  &.current {
+    background-color: $sponge_yellow;
+    color: $sponge_grey;
+    border: 1px solid $sponge_dark_yellow;
+    font-weight: bold;
 
-  &:hover {
-    background-color: #f9ed9e;
+    &:hover {
+      background-color: #f9ed9e;
+    }
   }
 }
 
 .btn-default {
   background-color: #848485;
   border: 1px solid #848485;
-  transition: all .3s ease-in-out;
 
   &:hover {
     background-color: $sponge_grey;
     border: 1px solid $sponge_grey;
+  }
+}
+
+.btn-outline {
+  background: none;
+  color: #fff;
+  margin-top: 15px;
+  border: solid 2px #fff;
+
+  &:hover, &:focus, &:active, &.active {
+    color: $sponge_yellow;
+    background-color: white;
   }
 }

--- a/src/scss/_chat.scss
+++ b/src/scss/_chat.scss
@@ -60,5 +60,4 @@
     padding-top: 30px;
     padding-bottom: 40px;
   }
-
 }

--- a/src/scss/_downloads.scss
+++ b/src/scss/_downloads.scss
@@ -23,6 +23,8 @@
  * THE SOFTWARE.
  */
 
+@import "variables";
+
 #downloads {
   text-align: center;
 
@@ -78,14 +80,14 @@
   text-align: center;
 
   &.spongevanilla {
-    background-color: #917300;
+    background-color: $spongevanilla_color;
   }
 
   &.spongeforge {
-    background-color: #910020;
+    background-color: $spongeforge_color;
   }
 
   &.spongeapi {
-    background-color: #009172;
+    background-color: $spongeapi_color;
   }
 }

--- a/src/scss/_footer.scss
+++ b/src/scss/_footer.scss
@@ -23,6 +23,8 @@
  * THE SOFTWARE.
  */
 
+@import "variables";
+
 footer {
   color: #fff;
   text-align: center;

--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -23,6 +23,8 @@
  * THE SOFTWARE.
  */
 
+@import "variables";
+
 header {
   background-image: url(../img/backgrounds/sponsors-content.jpg);
   background-repeat: no-repeat;

--- a/src/scss/_index.scss
+++ b/src/scss/_index.scss
@@ -23,6 +23,8 @@
  * THE SOFTWARE.
  */
 
+@import "mixins/sponsors";
+
 #index-page {
   header {
     padding-top: 4em;
@@ -91,13 +93,8 @@
       padding: 1.5em 0;
 
       img {
+        @include sponsor-img;
         max-width: 95%;
-        max-height: 50px;
-        transition: all 0.2s ease-in-out;
-
-        &:hover {
-          transform: scale(1.1);
-        }
       }
     }
   }

--- a/src/scss/_index_sections.scss
+++ b/src/scss/_index_sections.scss
@@ -23,6 +23,9 @@
  * THE SOFTWARE.
  */
 
+@import "variables";
+@import "mixins/font";
+
 #index-page section {
   padding: 40px 0;
   border-bottom: 1px solid rgba(0, 0, 0, .2);

--- a/src/scss/_index_sections.scss
+++ b/src/scss/_index_sections.scss
@@ -138,7 +138,7 @@
   }
 
   .btn {
-    font-family: $sponge_headline_font;
+    @include montserrat;
   }
 }
 

--- a/src/scss/_sponge_variables.scss
+++ b/src/scss/_sponge_variables.scss
@@ -23,17 +23,40 @@
  * THE SOFTWARE.
  */
 
-// Brand colors
+// Helper functions
+@function tint($color, $percentage) {
+  @return mix(white, $color, $percentage);
+}
+
+@function shade($color, $percentage) {
+  @return mix(black, $color, $percentage);
+}
+
+// Sponge brand colors
 $sponge_yellow: #f7cf0d;
 $sponge_dark_yellow: #917300;
 $sponge_grey: #333333;
-$sponge_dark_grey: #2b2b2b;
+$sponge_dark_grey: shade($sponge_grey, 15%);
 
-$sponge_headline_font: Montserrat, "Helvetica Neue", Helvetica, Arial, sans-serif;
+// Bootstrap configuration
+$font-size-base: 16px; // todo: bootstrap4 -> 1rem
 
-.sponge-headline {
-  font-family: $sponge_headline_font;
-  font-weight: 700;
+$brand-primary:   $sponge_grey;
+$brand-secondary: tint($sponge_grey, 50%);
+
+$navbar-dark-hover-color: $sponge_yellow;
+$dropdown-link-hover-color: $sponge_grey;
+$dropdown-link-hover-bg: $sponge_yellow;
+$dropdown-link-active-color: black;
+$dropdown-link-active-bg: $sponge_yellow;
+
+@import "bootswatch/flatly/variables";
+
+// Mixins
+@mixin montserrat {
+  font-family: Montserrat, $font-family-base;
+}
+
+@mixin uppercase {
   text-transform: uppercase;
-  text-decoration: none;
 }

--- a/src/scss/_sponsors.scss
+++ b/src/scss/_sponsors.scss
@@ -23,6 +23,8 @@
  * THE SOFTWARE.
  */
 
+@import "mixins/sponsors";
+
 #sponsors-page #main-content {
   margin-top: $sp_topbar_height;
 
@@ -51,9 +53,9 @@
 
 #sponsors-introduction {
   .introduction {
+    @include montserrat;
+    @include uppercase;
     font-size: 18px;
-    font-family: $sponge_headline_font;
-    text-transform: uppercase;
     line-height: 1.1;
   }
 }
@@ -83,13 +85,8 @@
       margin-bottom: 50px;
 
       img {
+        @include sponsor-img;
         max-width: 85%;
-        max-height: 50px;
-        transition: all 0.2s ease-in-out;
-
-        &:hover {
-          transform: scale(1.1);
-        }
 
         @media (max-width: 560px) {
           width: 100%;

--- a/src/scss/_sponsors.scss
+++ b/src/scss/_sponsors.scss
@@ -23,6 +23,8 @@
  * THE SOFTWARE.
  */
 
+@import "variables";
+@import "mixins/font";
 @import "mixins/sponsors";
 
 #sponsors-page #main-content {

--- a/src/scss/_topbar.scss
+++ b/src/scss/_topbar.scss
@@ -23,6 +23,9 @@
  * THE SOFTWARE.
  */
 
+@import "variables";
+@import "mixins/font";
+
 $sp_logo_offset_x: 0;
 $sp_logo_offset_y: -20px;
 $sp_topbar_height: 63px;

--- a/src/scss/_topbar.scss
+++ b/src/scss/_topbar.scss
@@ -75,7 +75,8 @@ $sp_logo_width: 200px;
     padding-left: 20px;
     padding-top: 11px;
 
-    @extend .sponge-headline;
+    @include montserrat;
+    @include uppercase;
     font-weight: 700;
 
     * {

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -31,6 +31,10 @@ $sponge_dark_yellow: #917300;
 $sponge_grey: #333333;
 $sponge_dark_grey: shade($sponge_grey, 15%);
 
+$spongevanilla_color: #917300;
+$spongeforge_color: #910020;
+$spongeapi_color: #009172;
+
 // Bootstrap configuration
 $font-size-base: 16px; // todo: bootstrap4 -> 1rem
 

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -23,14 +23,7 @@
  * THE SOFTWARE.
  */
 
-// Helper functions
-@function tint($color, $percentage) {
-  @return mix(white, $color, $percentage);
-}
-
-@function shade($color, $percentage) {
-  @return mix(black, $color, $percentage);
-}
+@import "mixins/colour";
 
 // Sponge brand colors
 $sponge_yellow: #f7cf0d;
@@ -51,12 +44,3 @@ $dropdown-link-active-color: black;
 $dropdown-link-active-bg: $sponge_yellow;
 
 @import "bootswatch/flatly/variables";
-
-// Mixins
-@mixin montserrat {
-  font-family: Montserrat, $font-family-base;
-}
-
-@mixin uppercase {
-  text-transform: uppercase;
-}

--- a/src/scss/mixins/_colour.scss
+++ b/src/scss/mixins/_colour.scss
@@ -23,89 +23,11 @@
  * THE SOFTWARE.
  */
 
-@import "variables";
-@import "mixins/sponsors";
+// Helper functions
+@function tint($color, $percentage) {
+  @return mix(white, $color, $percentage);
+}
 
-#index-page {
-  header {
-    padding-top: 4em;
-    padding-bottom: 0;
-
-    text-align: center;
-
-    img {
-      display: block;
-      margin: 0 auto 20px;
-    }
-
-    .logo {
-      height: 256px;
-      width: 256px;
-      padding: 28px;
-    }
-
-    .intro-text {
-      .name {
-        color: $sponge_dark_grey;
-        font-size: 3em;
-        padding-top: 0.4em;
-      }
-
-      .skills {
-        font-size: 1.5em;
-        color: rgba(0, 0, 0, 0.8);
-      }
-    }
-
-    @media (min-width: 768px) {
-      .container {
-        padding: 40px 0;
-      }
-
-      .intro-text {
-        .name {
-          font-size: 4.75em;
-        }
-
-        .skills {
-          font-size: 1.75em;
-        }
-      }
-    }
-
-    .container {
-      display: flex;
-      flex-wrap: wrap;
-      padding: 0;
-    }
-
-    #main-display {
-      display: flex;
-      align-items: center;
-
-      @media (min-width: 992px) {
-        &.col-lg-8 {
-          width: 66% !important;
-        }
-      }
-    }
-
-    #sponsors-display {
-      padding: 1.5em 0;
-
-      img {
-        @include sponsor-img;
-        max-width: 95%;
-      }
-    }
-  }
-
-  h2 {
-    // Larger section titles
-    font-size: 39px;
-  }
-
-  #main-content {
-    text-align: center;
-  }
+@function shade($color, $percentage) {
+  @return mix(black, $color, $percentage);
 }

--- a/src/scss/mixins/_font.scss
+++ b/src/scss/mixins/_font.scss
@@ -23,89 +23,13 @@
  * THE SOFTWARE.
  */
 
-@import "variables";
-@import "mixins/sponsors";
+// Fonts
+@import url("https://fonts.googleapis.com/css?family=Montserrat:400,500,600,700");
+@mixin montserrat {
+  font-family: Montserrat, $font-family-base;
+}
 
-#index-page {
-  header {
-    padding-top: 4em;
-    padding-bottom: 0;
-
-    text-align: center;
-
-    img {
-      display: block;
-      margin: 0 auto 20px;
-    }
-
-    .logo {
-      height: 256px;
-      width: 256px;
-      padding: 28px;
-    }
-
-    .intro-text {
-      .name {
-        color: $sponge_dark_grey;
-        font-size: 3em;
-        padding-top: 0.4em;
-      }
-
-      .skills {
-        font-size: 1.5em;
-        color: rgba(0, 0, 0, 0.8);
-      }
-    }
-
-    @media (min-width: 768px) {
-      .container {
-        padding: 40px 0;
-      }
-
-      .intro-text {
-        .name {
-          font-size: 4.75em;
-        }
-
-        .skills {
-          font-size: 1.75em;
-        }
-      }
-    }
-
-    .container {
-      display: flex;
-      flex-wrap: wrap;
-      padding: 0;
-    }
-
-    #main-display {
-      display: flex;
-      align-items: center;
-
-      @media (min-width: 992px) {
-        &.col-lg-8 {
-          width: 66% !important;
-        }
-      }
-    }
-
-    #sponsors-display {
-      padding: 1.5em 0;
-
-      img {
-        @include sponsor-img;
-        max-width: 95%;
-      }
-    }
-  }
-
-  h2 {
-    // Larger section titles
-    font-size: 39px;
-  }
-
-  #main-content {
-    text-align: center;
-  }
+// Styling
+@mixin uppercase {
+  text-transform: uppercase;
 }

--- a/src/scss/mixins/_sponsors.scss
+++ b/src/scss/mixins/_sponsors.scss
@@ -23,19 +23,11 @@
  * THE SOFTWARE.
  */
 
-@import "sponge_variables";
-@import "bootstrap-sass/bootstrap";
-@import "bootswatch/flatly/bootswatch";
+@mixin sponsor-img {
+  max-height: 50px;
+  transition: all 0.2s ease-in-out;
 
-@import "spongebootstrap";
-
-@import "base";
-@import "header";
-@import "topbar";
-@import "footer";
-
-@import "index";
-@import "index_sections";
-@import "sponsors";
-@import "chat";
-@import "downloads";
+  &:hover {
+    transform: scale(1.1);
+  }
+}

--- a/src/scss/spongehome.scss
+++ b/src/scss/spongehome.scss
@@ -23,15 +23,14 @@
  * THE SOFTWARE.
  */
 
-@import "sponge_variables";
+@import "variables";
 @import "bootstrap-sass/bootstrap";
 @import "bootswatch/flatly/bootswatch";
-
-@import "spongebootstrap";
 
 @import "base";
 @import "header";
 @import "topbar";
+@import "buttons";
 @import "footer";
 
 @import "index";


### PR DESCRIPTION
The existing styles need to be reviewed, and made to fit in now that we have access
to Bootstrap variables.

SpongeDownloads is a good reference point for this work, and ultimately SpongeHome
will be upgraded to Bootstrap v4 - at which point the stylesheets will be spun off
so they can be shared across the Sponge web properties (home, downloads, and ore).