### PR TITLE
Display emojis in announcement titles

### DIFF
--- a/controllers/announcements.go
+++ b/controllers/announcements.go
@@ -37,10 +37,11 @@ import (
 )
 
 type Topic struct {
-	ID        int    `json:"id"`
-	Title     string `json:"title"`
-	Slug      string `json:"slug"`
-	Archetype string `json:"archetype"`
+	ID           int    `json:"id"`
+	Title        string `json:"title"`
+	UnicodeTitle string `json:"unicode_title"`
+	Slug         string `json:"slug"`
+	Archetype    string `json:"archetype"`
 }
 
 type TopicList struct {
@@ -48,7 +49,7 @@ type TopicList struct {
 }
 
 func (t *TopicList) GetRegularTopics() []Topic {
-	var topics = []Topic{}
+	var topics []Topic
 
 	for _, topic := range t.Topics {
 		if topic.Archetype == "regular" {
@@ -144,8 +145,18 @@ func getAnnouncement(topic Topic) (Announcement, error) {
 		return Announcement{}, err
 	}
 
+	// Titles with emojis in, will appear as `:emoji:` in the plain title,
+	// in those cases `unicode_title` exists, with the emoji in unicode form.
+	// We can use that to display emojis in titles.
+	var title string
+	if topic.UnicodeTitle != "" {
+		title = topic.UnicodeTitle
+	} else {
+		title = topic.Title
+	}
+
 	return Announcement{
-		Title:   topic.Title,
+		Title:   title,
 		Content: res.PostStream.Posts[0].Cooked,
 		URL:     "https://forums.spongepowered.org/t/" + topic.Slug,
 	}, nil

--- a/controllers/statusz.go
+++ b/controllers/statusz.go
@@ -31,13 +31,15 @@ import (
 	"net/http"
 )
 
-const buildNum  = "BUILD_NUMBER"
-const gitBranch = "GIT_BRANCH"
-const gitCommit = "GIT_COMMIT"
-const jobName   = "JOB_NAME"
-const buildTag  = "BUILD_TAG"
-const spongeEnv = "SPONGE_ENV"
-const service   = "SERVICE"
+const (
+	buildNum  = "BUILD_NUMBER"
+	gitBranch = "GIT_BRANCH"
+	gitCommit = "GIT_COMMIT"
+	jobName   = "JOB_NAME"
+	buildTag  = "BUILD_TAG"
+	spongeEnv = "SPONGE_ENV"
+	service   = "SERVICE"
+)
 
 func env(name string) string {
 	val := os.Getenv(name)

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -79,7 +79,7 @@
             <a class="col-xs-6 col-md-2 col-sm-4 icon" href="https://github.com/SpongePowered"><i class="fa-fw fa fa-code"></i><p>Code</p></a>
             <a class="col-xs-6 col-md-2 col-sm-4 icon" href="https://www.spongepowered.org/downloads"><i class="fa-fw fa fa-download"></i><p>Downloads</p></a>
             <a class="col-xs-6 col-md-2 col-sm-4 icon" href="https://docs.spongepowered.org/"><i class="fa-fw fa fa-book"></i><p>Docs</p></a>
-            <a class="col-xs-6 col-md-2 col-sm-4 icon" href="https://ore.spongepowered.org"><img src="assets/img/icons/ore.svg" alt="" class="fa-fw fa ore-icon"></i><p>Plugins (Ore)</p></a>
+            <a class="col-xs-6 col-md-2 col-sm-4 icon" href="https://ore.spongepowered.org"><img src="assets/img/icons/ore.svg" alt="" class="fa-fw fa ore-icon"><p>Plugins (Ore)</p></a>
             <a class="col-xs-6 col-md-2 col-sm-4 icon" href="chat"><i class="fa fa-comment"></i><p>Chat</p></a>
         </div>
     </div>


### PR DESCRIPTION
Alternatively, you could process the announcement titles and replace with `<img>` tags, but this is a simpler solution.

![https://i.imgur.com/9Kg4Cn8.png](https://i.imgur.com/9Kg4Cn8.png)