### PR TITLE
Replace API download with Neo download

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -188,12 +188,12 @@
                         <i class="fa fa-download"></i>Download</a>
                     <p class="recommendation">Recommended for running plugins together with Forge mods.</p></div>
                 <div class="col-sm-4 platform">
-                    <h3><span>Sponge<span class="platform-badge spongeapi">API</span></span></h3>
-                    <p class="description">SpongeAPI is the tool developers use to create plugins for the Sponge
+                    <h3><span>Sponge<span class="platform-badge spongeneo">Neo</span></span></h3>
+                    <p class="description">SpongeNeo is the implementation of the Sponge API on the NeoForge
                         platform.</p>
-                    <a href="https://www.spongepowered.org/downloads/spongeapi" class="btn btn-primary styled-btn">
+                    <a href="https://www.spongepowered.org/downloads/spongeneo" class="btn btn-primary styled-btn">
                         <i class="fa fa-download"></i>Download</a>
-                    <p class="recommendation">Recommended for plugin developers.</p></div>
+                    <p class="recommendation">Recommended for running plugins together with NeoForge mods.</p></div>
             </div>
         </div>
     </div>

--- a/src/scss/_downloads.scss
+++ b/src/scss/_downloads.scss
@@ -90,6 +90,6 @@
   }
 
   &.spongeneo {
-    background-color: #009172;
+    background-color: #cc6f2f;
   }
 }

--- a/src/scss/_downloads.scss
+++ b/src/scss/_downloads.scss
@@ -88,4 +88,8 @@
   &.spongeapi {
     background-color: #009172;
   }
+
+  &.spongeneo {
+    background-color: #009172;
+  }
 }


### PR DESCRIPTION
As the API is not meant to be downloaded anymore and SpongeNeo now exists, replace the API download on the frontpage with Neo instead.

For now, using the same color that API had.